### PR TITLE
Fix prerelease version detection and refresh dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           lfs: true
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2.9.1
 
       - name: cargo build
         run: cargo build
@@ -32,14 +30,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           lfs: true
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2.9.1
 
       - name: cargo fmt
         run: cargo fmt --all -- --check
@@ -57,8 +54,8 @@ jobs:
     name: cargo-deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@v7
+      - uses: EmbarkStudios/cargo-deny-action@v2.1.1
         with:
           rust-version: "1.92.0"
           log-level: error
@@ -68,11 +65,9 @@ jobs:
     name: Publish Check
     runs-on: ubuntu-latest
     steps:
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v7
+      - uses: Swatinem/rust-cache@v2.9.1
       - run: cargo fetch
       - name: cargo publish
         run: cargo publish --dry-run
@@ -81,16 +76,14 @@ jobs:
     name: Typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: crate-ci/typos@master
+      - uses: actions/checkout@v7
+      - uses: crate-ci/typos@v1.48.0
 
   cargo-machete:
     runs-on: ubuntu-latest
     steps:
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2.9.1
+      - uses: actions/checkout@v7
       - name: Machete
-        uses: bnjbvr/cargo-machete@main
+        uses: bnjbvr/cargo-machete@v0.9.2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,14 +7,10 @@ jobs:
   create-windows-binaries:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install stable
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Build cargo-binlist
         run: |
@@ -25,7 +21,7 @@ jobs:
         id: tagName
         run: |
           VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
-          echo "::set-output name=tag::$VERSION"
+          echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build package
         id: package
@@ -34,12 +30,12 @@ jobs:
           ARCHIVE_TARGET="x86_64-pc-windows-msvc"
           ARCHIVE_NAME="cargo-binlist-${{ steps.tagName.outputs.tag }}-$ARCHIVE_TARGET"
           ARCHIVE_FILE="${ARCHIVE_NAME}.zip"
-          7z a ${ARCHIVE_FILE} ./target/release/cargo-binlist.exe
-          echo "::set-output name=file::${ARCHIVE_FILE}"
-          echo "::set-output name=name::${ARCHIVE_NAME}.zip"
+          7z a "$ARCHIVE_FILE" ./target/release/cargo-binlist.exe
+          echo "file=$ARCHIVE_FILE" >> "$GITHUB_OUTPUT"
+          echo "name=${ARCHIVE_NAME}.zip" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.package.outputs.name }}
           path: ${{ steps.package.outputs.file }}
@@ -57,15 +53,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
 
       - name: Install musl
         if: contains(matrix.target, 'linux-musl')
@@ -84,19 +77,19 @@ jobs:
         id: tagName
         run: |
           VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
-          echo "::set-output name=tag::$VERSION"
+          echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build package
         id: package
         run: |
           TAR_FILE=cargo-binlist-${{ steps.tagName.outputs.tag }}-${{ matrix.target }}
           cd target/${{ matrix.target }}/release
-          tar -czvf $GITHUB_WORKSPACE/$TAR_FILE.tar.gz cargo-binlist
-          echo ::set-output "name=name::${TAR_FILE}"
-          echo ::set-output "name=file::${TAR_FILE}.tar.gz "
+          tar -czvf "$GITHUB_WORKSPACE/$TAR_FILE.tar.gz" cargo-binlist
+          echo "name=$TAR_FILE" >> "$GITHUB_OUTPUT"
+          echo "file=${TAR_FILE}.tar.gz" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.package.outputs.name }}
           path: ${{ steps.package.outputs.file }}
@@ -107,14 +100,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: Install Rust stable
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Create Cargo.lock
         run: |
@@ -124,15 +113,15 @@ jobs:
         id: tagName
         run: |
           VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
-          echo "::set-output name=tag::$VERSION"
+          echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ./binaries
 
       - name: Create a release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3.0.2
         with:
           name: v${{ steps.tagName.outputs.tag }}
           files: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "atomic-waker"
@@ -78,9 +78,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bumpalo"
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -130,9 +130,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -167,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -179,14 +179,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -324,7 +324,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -360,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -381,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -406,15 +406,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -423,38 +423,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -541,9 +541,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -741,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -889,9 +889,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -954,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1111,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -1156,38 +1156,38 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1284,9 +1284,20 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1310,7 +1321,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1337,29 +1348,29 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "libc",
@@ -1379,9 +1390,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1414,9 +1425,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -1611,7 +1622,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -1646,18 +1657,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "which"
-version = "8.0.4"
+version = "8.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
 dependencies = [
  "libc",
 ]
@@ -1806,7 +1817,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -1827,7 +1838,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -1867,7 +1878,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,5 +1,6 @@
 use std::{cmp::Ordering, time::Duration};
 
+use anyhow::Context as _;
 use comfy_table::{Attribute, Cell, Color};
 use crates_io_api::SyncClient;
 use semver::Version;
@@ -64,7 +65,19 @@ impl PackageInfo {
         let client = SyncClient::new("cargo-binlist", Duration::from_secs(1))?;
         log::debug!("Fetching latest version for {}", self.name);
         let cr = client.get_crate(&self.name)?;
-        let version = Version::parse(&cr.crate_data.max_version)?;
-        Ok(version)
+        latest_installable_version(
+            &cr.crate_data.max_version,
+            cr.crate_data.max_stable_version.as_deref(),
+        )
     }
+}
+
+pub fn latest_installable_version(
+    max_version: &str,
+    max_stable_version: Option<&str>,
+) -> anyhow::Result<Version> {
+    let version = max_stable_version.with_context(|| {
+        format!("No stable version is available; latest release is {max_version}")
+    })?;
+    Version::parse(version).context("Failed to parse latest stable version")
 }

--- a/src/logic.rs
+++ b/src/logic.rs
@@ -215,7 +215,7 @@ pub fn list_pkgs(pkg_vec: Vec<PackageInfo>, only_updates: bool, uncondensed: boo
     println!("Count: {len}");
 }
 
-fn create_table(pkgs: &[PackageInfo], uncondensed: bool) -> Table {
+pub fn create_table(pkgs: &[PackageInfo], uncondensed: bool) -> Table {
     let header = vec![
         Cell::new("Name").add_attribute(Attribute::Bold),
         Cell::new("Version").add_attribute(Attribute::Bold),

--- a/src/test.rs
+++ b/src/test.rs
@@ -10,7 +10,7 @@ use tempfile::TempDir;
 
 use crate::{
     cli::{Cli, ListOpts, Opts, UpdateOpts},
-    data::{PackageInfo, VersionCheck},
+    data::{PackageInfo, VersionCheck, latest_installable_version},
     logic,
 };
 
@@ -123,6 +123,29 @@ fn test_packageinfo() {
 
     pkg.set_info(&Version::new(0, 9, 9));
     assert_eq!(pkg.info, VersionCheck::LocalNewer);
+}
+
+#[test]
+fn test_latest_installable_version_ignores_prereleases() {
+    let mut pkg = PackageInfo::new("dioxus-cli".to_owned(), Version::new(0, 7, 9));
+    let latest = latest_installable_version("0.8.0-alpha.0", Some("0.7.9")).unwrap();
+
+    pkg.set_info(&latest);
+
+    assert_eq!(latest, Version::new(0, 7, 9));
+    assert_eq!(pkg.info, VersionCheck::UpToDate);
+}
+
+#[test]
+fn test_latest_installable_version_requires_a_stable_release() {
+    let err = latest_installable_version("1.0.0-alpha.1", None)
+        .err()
+        .unwrap();
+
+    assert!(
+        err.to_string().contains("No stable version is available"),
+        "unexpected error: {err}"
+    );
 }
 
 #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -68,6 +68,24 @@ cargo-edit v0.13.0:
     assert!(matches!(parsed[2].info, VersionCheck::UpToDate));
     assert!(matches!(parsed[3].info, VersionCheck::LocalNewer));
 }
+
+#[test]
+fn test_get_package_infos_ignores_invalid_lines_and_failed_lookups() {
+    let output = r"
+not a package
+cargo-deny v0.16.1:
+    cargo-deny
+";
+
+    let parsed = logic::get_package_infos_with_latest(output, |_| {
+        Err(anyhow::anyhow!("crate is unavailable"))
+    });
+
+    assert_eq!(parsed.len(), 1);
+    assert_eq!(parsed[0].name, "cargo-deny");
+    assert_eq!(parsed[0].info, VersionCheck::UnAvailable);
+}
+
 #[test]
 fn test_parse_package_line() {
     let line = "tester v1.10.18:";
@@ -81,6 +99,17 @@ fn test_parse_package_line_invalid() {
     let line = "not a package line";
     let err = logic::parse_package_line(line).err().unwrap();
     assert!(err.to_string().contains("Failed to parse package line"));
+}
+
+#[test]
+fn test_parse_package_line_invalid_version() {
+    let err = logic::parse_package_line("tester not-a-version:")
+        .err()
+        .unwrap();
+    assert!(
+        err.to_string().contains("unexpected character"),
+        "unexpected parse error: {err}"
+    );
 }
 
 #[test]
@@ -99,6 +128,35 @@ fn test_packageinfo() {
 #[test]
 fn test_cli_update() {
     logic::update(&[], true).unwrap();
+}
+
+#[test]
+#[cfg(unix)]
+fn test_update_ignores_packages_without_updates() {
+    let temp_dir = TempDir::new().unwrap();
+    let log_path = temp_dir.path().join("cargo_log.txt");
+    let script = r#"#!/bin/sh
+script_dir=$(dirname "$0")
+printf "%s\n" "$@" > "$script_dir/cargo_log.txt"
+exit 0
+"#;
+    let cargo_path = write_fake_cargo(temp_dir.path(), script);
+    let packages = vec![
+        PackageInfo {
+            name: "cargo-binstall".to_owned(),
+            version: Version::new(1, 0, 0),
+            info: VersionCheck::UpToDate,
+        },
+        PackageInfo {
+            name: "cargo-deny".to_owned(),
+            version: Version::new(0, 16, 1),
+            info: VersionCheck::LocalNewer,
+        },
+    ];
+
+    logic::update_with_cargo(&packages, true, &cargo_path).unwrap();
+
+    assert!(!log_path.exists());
 }
 
 #[test]
@@ -216,13 +274,79 @@ exit 1
 #[test]
 fn test_version_occurrences() {
     let pkgs = vec![
-        PackageInfo::new("cargo-binstall".to_owned(), Version::new(1, 10, 18)),
-        PackageInfo::new("cargo-bloat".to_owned(), Version::new(0, 12, 1)),
-        PackageInfo::new("cargo-deny".to_owned(), Version::new(0, 16, 1)),
+        PackageInfo {
+            name: "cargo-binstall".to_owned(),
+            version: Version::new(1, 10, 18),
+            info: VersionCheck::NewerAvailable(Version::new(1, 10, 19)),
+        },
+        PackageInfo {
+            name: "cargo-bloat".to_owned(),
+            version: Version::new(0, 12, 1),
+            info: VersionCheck::UpToDate,
+        },
+        PackageInfo {
+            name: "cargo-deny".to_owned(),
+            version: Version::new(0, 16, 1),
+            info: VersionCheck::LocalNewer,
+        },
         PackageInfo::new("cargo-edit".to_owned(), Version::new(0, 13, 0)),
     ];
 
     logic::version_occurrences(&pkgs);
+}
+
+#[test]
+fn test_create_table_sorts_updates_first_and_supports_both_layouts() {
+    let packages = vec![
+        PackageInfo {
+            name: "z-current".to_owned(),
+            version: Version::new(1, 0, 0),
+            info: VersionCheck::UpToDate,
+        },
+        PackageInfo {
+            name: "b-update".to_owned(),
+            version: Version::new(1, 0, 0),
+            info: VersionCheck::NewerAvailable(Version::new(1, 1, 0)),
+        },
+        PackageInfo {
+            name: "a-update".to_owned(),
+            version: Version::new(1, 0, 0),
+            info: VersionCheck::NewerAvailable(Version::new(1, 2, 0)),
+        },
+    ];
+
+    let condensed = logic::create_table(&packages, false).to_string();
+    let uncondensed = logic::create_table(&packages, true).to_string();
+
+    let first_update = condensed.find("a-update").unwrap();
+    let second_update = condensed.find("b-update").unwrap();
+    let current = condensed.find("z-current").unwrap();
+    assert!(
+        first_update < second_update && second_update < current,
+        "packages were not ordered correctly:\n{condensed}"
+    );
+    assert!(
+        uncondensed.lines().count() > condensed.lines().count(),
+        "uncondensed layout should use more table rows"
+    );
+}
+
+#[test]
+fn test_list_pkgs_handles_filters_and_empty_results() {
+    let current = PackageInfo {
+        name: "cargo-current".to_owned(),
+        version: Version::new(1, 0, 0),
+        info: VersionCheck::UpToDate,
+    };
+    let update = PackageInfo {
+        name: "cargo-update".to_owned(),
+        version: Version::new(1, 0, 0),
+        info: VersionCheck::NewerAvailable(Version::new(1, 1, 0)),
+    };
+
+    logic::list_pkgs(Vec::new(), false, false);
+    logic::list_pkgs(vec![current], true, false);
+    logic::list_pkgs(vec![update], true, true);
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,154 @@
+#![expect(clippy::unwrap_used, reason = "unwrap is used for test setup")]
+
+#[cfg(unix)]
+use std::fs;
+use std::{
+    env,
+    path::Path,
+    process::{Command, Output},
+};
+#[cfg(unix)]
+use tempfile::TempDir;
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_cargo-binlist"))
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+#[cfg(unix)]
+fn write_executable(dir: &Path, name: &str, script: &str) {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let path = dir.join(name);
+    fs::write(&path, script).unwrap();
+    let mut permissions = fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+#[cfg(unix)]
+fn run_with_path(args: &[&str], path_prefix: &Path) -> Output {
+    let current_path = env::var_os("PATH").unwrap();
+    let path = env::join_paths(
+        std::iter::once(path_prefix.to_path_buf()).chain(env::split_paths(&current_path)),
+    )
+    .unwrap();
+
+    Command::new(env!("CARGO_BIN_EXE_cargo-binlist"))
+        .args(args)
+        .env("PATH", path)
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn cargo_subcommand_help_is_available() {
+    let output = run(&["binlist", "--help"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "help failed: {output:?}");
+    assert!(
+        stdout.contains("List all installed binaries"),
+        "unexpected help output: {stdout}"
+    );
+}
+
+#[test]
+fn version_is_available() {
+    let output = run(&["--version"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "version failed: {output:?}");
+    assert!(
+        stdout.contains(env!("CARGO_PKG_VERSION")),
+        "unexpected version output: {stdout}"
+    );
+}
+
+#[test]
+fn invalid_subcommand_is_rejected() {
+    let output = run(&["unknown"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "invalid command unexpectedly passed"
+    );
+    assert!(
+        stderr.contains("unrecognized subcommand"),
+        "unexpected error output: {stderr}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn init_succeeds_when_cargo_binstall_is_available() {
+    let temp_dir = TempDir::new().unwrap();
+    write_executable(temp_dir.path(), "cargo-binstall", "#!/bin/sh\nexit 0\n");
+
+    let output = run_with_path(&["init"], temp_dir.path());
+
+    assert!(output.status.success(), "init failed: {output:?}");
+}
+
+#[test]
+#[cfg(unix)]
+fn list_handles_an_empty_installation() {
+    let temp_dir = TempDir::new().unwrap();
+    write_executable(
+        temp_dir.path(),
+        "cargo",
+        "#!/bin/sh\n[ \"$1\" = install ] && [ \"$2\" = --list ]\n",
+    );
+
+    let output = run_with_path(&["list"], temp_dir.path());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "list failed: {output:?}");
+    assert!(
+        stdout.contains("No packages found"),
+        "unexpected list output: {stdout}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn update_handles_an_empty_installation() {
+    let temp_dir = TempDir::new().unwrap();
+    write_executable(
+        temp_dir.path(),
+        "cargo",
+        "#!/bin/sh\n[ \"$1\" = install ] && [ \"$2\" = --list ]\n",
+    );
+
+    let output = run_with_path(&["update", "--no-confirm"], temp_dir.path());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "update failed: {output:?}");
+    assert!(
+        stdout.contains("No packages to update"),
+        "unexpected update output: {stdout}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn list_reports_cargo_failures() {
+    let temp_dir = TempDir::new().unwrap();
+    write_executable(
+        temp_dir.path(),
+        "cargo",
+        "#!/bin/sh\necho boom >&2\nexit 1\n",
+    );
+
+    let output = run_with_path(&["list"], temp_dir.path());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        stderr.contains("Failed to get installed binaries: boom"),
+        "unexpected failure output: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- update Rust dependencies and GitHub Actions to their current releases
- expand unit and end-to-end CLI coverage
- use crates.io's stable version when deciding whether an installed binary can be updated

## Root cause

`cargo-binlist` compared installed versions with crates.io's `max_version`, which can be a prerelease. In issue #11, this advertised `dioxus-cli 0.8.0-alpha.0` as an update even though the default `cargo-binstall` version requirement continued to select stable `0.7.9`.

The version check now uses `max_stable_version`, so stable installations are no longer offered prerelease-only updates. Crates without any stable release remain unavailable to the default update flow.

Closes #11

## Validation

- `actionlint`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets` — 21 unit tests and 7 CLI integration tests
- `cargo build --release --locked`
- `cargo deny check`
- `cargo machete`
- `cargo publish --dry-run --locked`
- `cargo llvm-cov --all-targets` — 93.21% total line coverage; 85.61% across production files
- dependency freshness checks report all 12 direct dependencies current and no pending lockfile updates